### PR TITLE
Electricity context parsing fixes

### DIFF
--- a/prolexa_grammar.pl
+++ b/prolexa_grammar.pl
@@ -126,6 +126,8 @@ verb_phrase(N,X=>M) --> tverb(N, Y=>X=>M), article(ON), noun(ON, Y=>Lit), {Lit=.
 
 negated_verb_phrase(s,M) --> [is,not],property(s,M).
 negated_verb_phrase(p,M) --> [are,not],property(p,M).
+negated_verb_phrase(s,X=>M) --> [does,not],tverb(p, Y=>X=>M), article(ON), noun(ON, Y=>Lit), {Lit=..[P, Y], M=..[_, X, P]}.
+negated_verb_phrase(p,X=>M) --> [do,not],tverb(p, Y=>X=>M), article(ON), noun(ON, Y=>Lit), {Lit=..[P, Y], M=..[_, X, P]}.
 
 modal_phrase(_N, X=>has_ability(X, P)) --> [can, do], noun(s, Y=>Lit), {Lit=..[P,Y]}.
 modal_phrase(_N, X=>has_ability(X, P)) --> [can], iverb(p, Y=>Lit), {Lit=..[P,Y]}.

--- a/prolexa_grammar.pl
+++ b/prolexa_grammar.pl
@@ -91,6 +91,7 @@ sentence1(C) --> determiner(N,M1,M2,C),noun(N,M1),verb_phrase(N,M2).
 sentence1([(L:-true)]) --> proper_noun(N,X),verb_phrase(N,X=>L).
 sentence1([not(L):-true]) -->  proper_noun(N,X),negated_verb_phrase(N,X=>L).
 sentence1([(L:-true)]) --> article(N), noun(N,X=>Lit), verb_phrase(N,P=>L), {Lit=..[P, X]}.
+sentence1([(not(L):-true)]) --> article(N), noun(N,X=>Lit), negated_verb_phrase(N,P=>L), {Lit=..[P, X]}.
 sentence1(C) --> conditional(C).
 sentence1(C) --> conditional2(C).
 sentence1([(VM:-AM,NM)]) --> adjective(N, X=>AM), noun(N, X=>NM), verb_phrase(N, X=>VM).


### PR DESCRIPTION
Allow for negated transitive verb phrases in sentences (so can handle "If the circuit does not have the switch then the circuit is complete."). In this case the transtive verb phrase form must be like "does not ..." or "do not ...".

Closes #11 